### PR TITLE
Improve TTS mobile compatibility with text chunking and audio unlocking

### DIFF
--- a/src/components/TextToSpeechDrawer.tsx
+++ b/src/components/TextToSpeechDrawer.tsx
@@ -18,7 +18,7 @@ import {
   Stop as StopIcon,
   Speed as SpeedIcon,
 } from "@mui/icons-material";
-import { TTSState, TTSControls } from "~/hooks/useTextToSpeech";
+import { TTSState, TTSControls, formatTime } from "~/hooks/useTextToSpeech";
 
 interface TextToSpeechDrawerProps {
   open: boolean;
@@ -33,7 +33,7 @@ export default function TextToSpeechDrawer({
   ttsState,
   ttsControls,
 }: TextToSpeechDrawerProps) {
-  const { isPlaying, isPaused, rate, voice, availableVoices, isSupported, progress, currentChunk, totalChunks } = ttsState;
+  const { isPlaying, isPaused, rate, voice, availableVoices, isSupported, progress, currentTime, totalTime } = ttsState;
   const { play, pause, resume, stop, setRate, setVoice, seekTo } = ttsControls;
 
   const handlePlayPause = () => {
@@ -167,14 +167,14 @@ export default function TextToSpeechDrawer({
           </Box>
 
           {/* Progress Slider */}
-          {totalChunks > 0 && (
+          {totalTime > 0 && (
             <Box>
               <Box sx={{ display: "flex", justifyContent: "space-between", mb: 1 }}>
                 <Typography variant="body2" color="text.secondary">
-                  Position
+                  {formatTime(currentTime)}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {currentChunk + 1} / {totalChunks}
+                  {formatTime(totalTime)}
                 </Typography>
               </Box>
               <Slider
@@ -182,8 +182,7 @@ export default function TextToSpeechDrawer({
                 onChange={handleProgressChange}
                 min={0}
                 max={100}
-                step={totalChunks > 0 ? 100 / totalChunks : 1}
-                disabled={!isPlaying && !isPaused && totalChunks === 0}
+                step={1}
                 sx={{
                   '& .MuiSlider-thumb': {
                     width: 16,

--- a/src/components/TextToSpeechDrawer.tsx
+++ b/src/components/TextToSpeechDrawer.tsx
@@ -34,7 +34,7 @@ export default function TextToSpeechDrawer({
   ttsControls,
 }: TextToSpeechDrawerProps) {
   const { isPlaying, isPaused, rate, voice, availableVoices, isSupported, progress, currentTime, totalTime } = ttsState;
-  const { play, pause, resume, stop, setRate, setVoice, seekTo } = ttsControls;
+  const { play, pause, resume, stop, setRate, setVoice } = ttsControls;
 
   const handlePlayPause = () => {
     if (isPlaying && !isPaused) {
@@ -70,11 +70,6 @@ export default function TextToSpeechDrawer({
         setTimeout(() => play(), 50);
       }
     }
-  };
-
-  const handleProgressChange = (_event: Event, newValue: number | number[]) => {
-    const newProgress = newValue as number;
-    seekTo(newProgress);
   };
 
   if (!isSupported) {
@@ -179,14 +174,22 @@ export default function TextToSpeechDrawer({
               </Box>
               <Slider
                 value={progress}
-                onChange={handleProgressChange}
                 min={0}
                 max={100}
-                step={1}
+                disabled
                 sx={{
                   '& .MuiSlider-thumb': {
-                    width: 16,
-                    height: 16,
+                    width: 12,
+                    height: 12,
+                  },
+                  '&.Mui-disabled': {
+                    color: 'primary.main',
+                    '& .MuiSlider-thumb': {
+                      backgroundColor: 'primary.main',
+                    },
+                    '& .MuiSlider-track': {
+                      backgroundColor: 'primary.main',
+                    },
                   },
                 }}
               />

--- a/src/components/TextToSpeechDrawer.tsx
+++ b/src/components/TextToSpeechDrawer.tsx
@@ -34,7 +34,7 @@ export default function TextToSpeechDrawer({
   ttsControls,
 }: TextToSpeechDrawerProps) {
   const { isPlaying, isPaused, rate, voice, availableVoices, isSupported, progress, currentTime, totalTime } = ttsState;
-  const { play, pause, resume, stop, setRate, setVoice } = ttsControls;
+  const { play, pause, resume, stop, restart, setRate, setVoice } = ttsControls;
 
   const handlePlayPause = () => {
     if (isPlaying && !isPaused) {
@@ -53,10 +53,10 @@ export default function TextToSpeechDrawer({
   const handleRateChange = (_event: Event, newValue: number | number[]) => {
     const newRate = newValue as number;
     setRate(newRate);
-    // If currently playing, restart with new rate
+    // If currently playing, restart from current position with new rate
     if (isPlaying) {
-      stop();
-      setTimeout(() => play(), 50);
+      // Small delay to allow state update before restart
+      setTimeout(() => restart(), 50);
     }
   };
 
@@ -64,10 +64,10 @@ export default function TextToSpeechDrawer({
     const selectedVoice = availableVoices.find((v) => v.name === event.target.value);
     if (selectedVoice) {
       setVoice(selectedVoice);
-      // If currently playing, restart with new voice
+      // If currently playing, restart from current position with new voice
       if (isPlaying) {
-        stop();
-        setTimeout(() => play(), 50);
+        // Small delay to allow state update before restart
+        setTimeout(() => restart(), 50);
       }
     }
   };

--- a/src/components/TextToSpeechDrawer.tsx
+++ b/src/components/TextToSpeechDrawer.tsx
@@ -33,8 +33,8 @@ export default function TextToSpeechDrawer({
   ttsState,
   ttsControls,
 }: TextToSpeechDrawerProps) {
-  const { isPlaying, isPaused, rate, voice, availableVoices, isSupported } = ttsState;
-  const { play, pause, resume, stop, setRate, setVoice } = ttsControls;
+  const { isPlaying, isPaused, rate, voice, availableVoices, isSupported, progress, currentChunk, totalChunks } = ttsState;
+  const { play, pause, resume, stop, setRate, setVoice, seekTo } = ttsControls;
 
   const handlePlayPause = () => {
     if (isPlaying && !isPaused) {
@@ -70,6 +70,11 @@ export default function TextToSpeechDrawer({
         setTimeout(() => play(), 50);
       }
     }
+  };
+
+  const handleProgressChange = (_event: Event, newValue: number | number[]) => {
+    const newProgress = newValue as number;
+    seekTo(newProgress);
   };
 
   if (!isSupported) {
@@ -160,6 +165,34 @@ export default function TextToSpeechDrawer({
               </IconButton>
             </Tooltip>
           </Box>
+
+          {/* Progress Slider */}
+          {totalChunks > 0 && (
+            <Box>
+              <Box sx={{ display: "flex", justifyContent: "space-between", mb: 1 }}>
+                <Typography variant="body2" color="text.secondary">
+                  Position
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {currentChunk + 1} / {totalChunks}
+                </Typography>
+              </Box>
+              <Slider
+                value={progress}
+                onChange={handleProgressChange}
+                min={0}
+                max={100}
+                step={totalChunks > 0 ? 100 / totalChunks : 1}
+                disabled={!isPlaying && !isPaused && totalChunks === 0}
+                sx={{
+                  '& .MuiSlider-thumb': {
+                    width: 16,
+                    height: 16,
+                  },
+                }}
+              />
+            </Box>
+          )}
 
           {/* Speed Control */}
           <Box>

--- a/src/hooks/useTextToSpeech.test.ts
+++ b/src/hooks/useTextToSpeech.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for TTS text chunking logic
+ */
+
+import { splitTextIntoChunks } from './useTextToSpeech';
+
+describe('splitTextIntoChunks', () => {
+  describe('short text (no splitting needed)', () => {
+    it('should return single chunk for text shorter than maxLength', () => {
+      const text = 'Hello world.';
+      const result = splitTextIntoChunks(text, 100);
+      expect(result).toEqual(['Hello world.']);
+    });
+
+    it('should return single chunk for text equal to maxLength', () => {
+      const text = 'Hello';
+      const result = splitTextIntoChunks(text, 5);
+      expect(result).toEqual(['Hello']);
+    });
+
+    it('should handle empty text', () => {
+      const result = splitTextIntoChunks('', 100);
+      // Empty string returns single-element array with empty string that gets filtered
+      expect(result.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('splitting on sentence boundaries', () => {
+    it('should split on period followed by space', () => {
+      const text = 'First sentence. Second sentence. Third sentence.';
+      const result = splitTextIntoChunks(text, 20);
+      expect(result[0]).toBe('First sentence.');
+      expect(result.length).toBeGreaterThan(1);
+    });
+
+    it('should split on exclamation mark followed by space', () => {
+      const text = 'Wow! This is amazing! More text here.';
+      const result = splitTextIntoChunks(text, 10);
+      expect(result[0]).toBe('Wow!');
+    });
+
+    it('should split on question mark followed by space', () => {
+      const text = 'How are you? I am fine. Thanks for asking.';
+      const result = splitTextIntoChunks(text, 15);
+      expect(result[0]).toBe('How are you?');
+    });
+
+    it('should split on period followed by newline', () => {
+      const text = 'First sentence.\nSecond sentence.\nThird sentence.';
+      const result = splitTextIntoChunks(text, 20);
+      expect(result[0]).toBe('First sentence.');
+    });
+  });
+
+  describe('splitting on paragraph/newline boundaries', () => {
+    it('should split on newline when no sentence boundary found', () => {
+      const text = 'This is a long line without periods\nThis is another line';
+      const result = splitTextIntoChunks(text, 40);
+      expect(result[0]).toBe('This is a long line without periods');
+    });
+  });
+
+  describe('splitting on word boundaries', () => {
+    it('should split on space when no other boundary found', () => {
+      const text = 'word1 word2 word3 word4 word5';
+      const result = splitTextIntoChunks(text, 15);
+      // Should produce multiple chunks
+      expect(result.length).toBeGreaterThan(1);
+      // First chunk should be within limits
+      expect(result[0].length).toBeLessThanOrEqual(15);
+    });
+  });
+
+  describe('hard splitting', () => {
+    it('should hard split when no good boundary exists', () => {
+      const text = 'abcdefghijklmnopqrstuvwxyz';
+      const result = splitTextIntoChunks(text, 10);
+      // Should produce multiple chunks
+      expect(result.length).toBeGreaterThan(1);
+      // All chunks together should equal original
+      expect(result.join('')).toBe(text);
+    });
+  });
+
+  describe('multiple chunks', () => {
+    it('should correctly split long text into multiple chunks', () => {
+      const sentences = Array(10).fill('This is a test sentence.').join(' ');
+      const result = splitTextIntoChunks(sentences, 50);
+
+      expect(result.length).toBeGreaterThan(1);
+      // No chunk should exceed maxLength (allowing for trim variations)
+      result.forEach(chunk => {
+        expect(chunk.length).toBeLessThanOrEqual(55); // Small buffer for boundary handling
+      });
+    });
+
+    it('should preserve all text content across chunks', () => {
+      const text = 'First sentence. Second sentence. Third sentence. Fourth sentence.';
+      const result = splitTextIntoChunks(text, 20);
+
+      // Joining chunks should give us back all the content (minus whitespace trimming)
+      const rejoined = result.join(' ');
+      expect(rejoined).toContain('First');
+      expect(rejoined).toContain('Fourth');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle text with only whitespace', () => {
+      const result = splitTextIntoChunks('   ', 100);
+      // Whitespace-only text is preserved as a single chunk
+      expect(result.length).toBeLessThanOrEqual(1);
+    });
+
+    it('should handle text with many consecutive spaces', () => {
+      const text = 'Hello     world';
+      const result = splitTextIntoChunks(text, 100);
+      expect(result).toEqual(['Hello     world']);
+    });
+
+    it('should handle unicode characters', () => {
+      const text = 'Hello 世界. This is a test. 你好!';
+      const result = splitTextIntoChunks(text, 15);
+      expect(result.length).toBeGreaterThan(1);
+    });
+  });
+});

--- a/src/hooks/useTextToSpeech.test.ts
+++ b/src/hooks/useTextToSpeech.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for TTS text chunking logic
  */
 
-import { splitTextIntoChunks } from './useTextToSpeech';
+import { splitTextIntoChunks, formatTime } from './useTextToSpeech';
 
 describe('splitTextIntoChunks', () => {
   describe('short text (no splitting needed)', () => {
@@ -123,5 +123,36 @@ describe('splitTextIntoChunks', () => {
       const result = splitTextIntoChunks(text, 15);
       expect(result.length).toBeGreaterThan(1);
     });
+  });
+});
+
+describe('formatTime', () => {
+  it('should format seconds as m:ss', () => {
+    expect(formatTime(0)).toBe('0:00');
+    expect(formatTime(5)).toBe('0:05');
+    expect(formatTime(30)).toBe('0:30');
+    expect(formatTime(59)).toBe('0:59');
+  });
+
+  it('should format minutes and seconds', () => {
+    expect(formatTime(60)).toBe('1:00');
+    expect(formatTime(65)).toBe('1:05');
+    expect(formatTime(90)).toBe('1:30');
+    expect(formatTime(125)).toBe('2:05');
+    expect(formatTime(599)).toBe('9:59');
+    expect(formatTime(600)).toBe('10:00');
+  });
+
+  it('should format hours, minutes, and seconds', () => {
+    expect(formatTime(3600)).toBe('1:00:00');
+    expect(formatTime(3661)).toBe('1:01:01');
+    expect(formatTime(7200)).toBe('2:00:00');
+    expect(formatTime(3723)).toBe('1:02:03');
+  });
+
+  it('should handle edge cases', () => {
+    expect(formatTime(-1)).toBe('0:00');
+    expect(formatTime(NaN)).toBe('0:00');
+    expect(formatTime(Infinity)).toBe('0:00');
   });
 });

--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -302,20 +302,16 @@ export function useTextToSpeech(text: string): [TTSState, TTSControls] {
           clearTimeout(startTimeoutRef.current);
           startTimeoutRef.current = null;
         }
-        // Don't log "interrupted" or "canceled" errors as they're expected when stopping
+        // Don't log "interrupted" or "canceled" errors as they're expected when stopping/pausing
         if (event.error !== "interrupted" && event.error !== "canceled") {
           console.error("TTS: Speech synthesis error:", event.error);
-        }
-        // On error, try to continue with next chunk (unless it was a cancel)
-        if (event.error !== "interrupted" && event.error !== "canceled") {
+          // On real error, try to continue with next chunk
           if (!isStoppedRef.current) {
             currentChunkIndexRef.current++;
             playNextChunkRef.current?.();
           }
-        } else {
-          setIsPlaying(false);
-          setIsPaused(false);
         }
+        // For cancel/interrupt errors, do NOT change state here - let pause/stop/restart handle it
       };
 
       utteranceRef.current = utterance;

--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -19,69 +19,301 @@ export interface TTSControls {
   setVoice: (voice: SpeechSynthesisVoice) => void;
 }
 
+// Detect mobile/iOS for platform-specific workarounds
+const isMobile = typeof navigator !== "undefined" && /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+const isIOS = typeof navigator !== "undefined" && /iPhone|iPad|iPod/i.test(navigator.userAgent);
+
+// Maximum characters per utterance for mobile (mobile browsers struggle with long utterances)
+const MAX_UTTERANCE_LENGTH = isMobile ? 2000 : 10000;
+
+/**
+ * Split text into chunks for better mobile compatibility.
+ * Tries to split on sentence boundaries to maintain natural speech flow.
+ */
+function splitTextIntoChunks(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // Try to find a sentence boundary within the limit
+    let splitIndex = -1;
+    const searchText = remaining.substring(0, maxLength);
+
+    // Look for sentence endings (. ! ?) followed by space or end
+    const sentenceEndings = ['. ', '! ', '? ', '.\n', '!\n', '?\n'];
+    for (const ending of sentenceEndings) {
+      const lastIndex = searchText.lastIndexOf(ending);
+      if (lastIndex > splitIndex) {
+        splitIndex = lastIndex + ending.length - 1;
+      }
+    }
+
+    // If no sentence boundary, try paragraph or newline
+    if (splitIndex === -1) {
+      const newlineIndex = searchText.lastIndexOf('\n');
+      if (newlineIndex > maxLength * 0.5) {
+        splitIndex = newlineIndex;
+      }
+    }
+
+    // If still no good boundary, split on last space
+    if (splitIndex === -1) {
+      const spaceIndex = searchText.lastIndexOf(' ');
+      if (spaceIndex > maxLength * 0.5) {
+        splitIndex = spaceIndex;
+      }
+    }
+
+    // Last resort: hard cut at max length
+    if (splitIndex === -1) {
+      splitIndex = maxLength;
+    }
+
+    chunks.push(remaining.substring(0, splitIndex + 1).trim());
+    remaining = remaining.substring(splitIndex + 1).trim();
+  }
+
+  return chunks.filter(chunk => chunk.length > 0);
+}
+
+/**
+ * Unlock audio on mobile browsers by creating and playing a silent audio context.
+ * Must be called from a user gesture (click/tap) handler.
+ */
+let audioUnlocked = false;
+function unlockAudio(): void {
+  if (audioUnlocked) return;
+
+  try {
+    // Create AudioContext to unlock audio playback
+    const AudioContext = window.AudioContext || (window as unknown as { webkitAudioContext: typeof window.AudioContext }).webkitAudioContext;
+    if (AudioContext) {
+      const ctx = new AudioContext();
+      // Create a short silent buffer and play it
+      const buffer = ctx.createBuffer(1, 1, 22050);
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+      source.connect(ctx.destination);
+      source.start(0);
+
+      // Also try resuming in case it was suspended
+      if (ctx.state === 'suspended') {
+        ctx.resume();
+      }
+
+      console.log("TTS: Audio context unlocked");
+    }
+    audioUnlocked = true;
+  } catch (e) {
+    console.warn("TTS: Failed to unlock audio context:", e);
+  }
+}
+
 /**
  * Hook for text-to-speech using the Web Speech API.
  * @param text - The text content to speak
  * @returns State and controls for TTS playback
  */
+// Check for browser support once at module level
+const isSpeechSynthesisSupported = typeof window !== "undefined" && "speechSynthesis" in window;
+
 export function useTextToSpeech(text: string): [TTSState, TTSControls] {
   const [isPlaying, setIsPlaying] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [rate, setRateState] = useState(1);
   const [voice, setVoiceState] = useState<SpeechSynthesisVoice | null>(null);
   const [availableVoices, setAvailableVoices] = useState<SpeechSynthesisVoice[]>([]);
-  const [isSupported, setIsSupported] = useState(false);
+  const isSupported = isSpeechSynthesisSupported;
 
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const textRef = useRef(text);
+  const chunksRef = useRef<string[]>([]);
+  const currentChunkIndexRef = useRef(0);
+  const isStoppedRef = useRef(false);
+  const startTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const playNextChunkRef = useRef<(() => void) | null>(null);
 
   // Update text ref when text changes
   useEffect(() => {
     textRef.current = text;
   }, [text]);
 
-  // Check for browser support and load voices
+  // Load voices on mount
   useEffect(() => {
-    if (typeof window !== "undefined" && "speechSynthesis" in window) {
-      setIsSupported(true);
+    if (!isSupported) return;
 
-      const loadVoices = () => {
-        const voices = window.speechSynthesis.getVoices();
-        console.log("TTS: Loaded", voices.length, "voices");
-        if (voices.length > 0) {
-          setAvailableVoices(voices);
-          // Set default voice (prefer English voices)
-          const englishVoice = voices.find(
-            (v) => v.lang.startsWith("en") && v.localService
-          );
-          const defaultVoice = englishVoice || voices[0];
-          if (!voice) {
-            console.log("TTS: Setting default voice:", defaultVoice?.name);
-            setVoiceState(defaultVoice);
-          }
+    const loadVoices = () => {
+      const voices = window.speechSynthesis.getVoices();
+      console.log("TTS: Loaded", voices.length, "voices");
+      if (voices.length > 0) {
+        setAvailableVoices(voices);
+        // Set default voice (prefer English voices)
+        const englishVoice = voices.find(
+          (v) => v.lang.startsWith("en") && v.localService
+        );
+        const defaultVoice = englishVoice || voices[0];
+        if (!voice) {
+          console.log("TTS: Setting default voice:", defaultVoice?.name);
+          setVoiceState(defaultVoice);
         }
-      };
+      }
+    };
 
-      // Load voices immediately if available
-      loadVoices();
+    // Load voices immediately if available
+    loadVoices();
 
-      // Also listen for voiceschanged event (needed for some browsers)
-      window.speechSynthesis.addEventListener("voiceschanged", loadVoices);
+    // Also listen for voiceschanged event (needed for some browsers)
+    window.speechSynthesis.addEventListener("voiceschanged", loadVoices);
 
-      return () => {
-        window.speechSynthesis.removeEventListener("voiceschanged", loadVoices);
-      };
-    }
-  }, [voice]);
+    return () => {
+      window.speechSynthesis.removeEventListener("voiceschanged", loadVoices);
+    };
+  }, [isSupported, voice]);
 
   // Clean up on unmount
   useEffect(() => {
     return () => {
+      isStoppedRef.current = true;
+      if (startTimeoutRef.current) {
+        clearTimeout(startTimeoutRef.current);
+      }
       if (typeof window !== "undefined" && "speechSynthesis" in window) {
         window.speechSynthesis.cancel();
       }
     };
   }, []);
+
+  // Speak a single chunk of text
+  const speakChunk = useCallback((chunkText: string) => {
+    // Cancel any ongoing speech first
+    window.speechSynthesis.cancel();
+
+    // Small delay after cancel for iOS
+    const startSpeaking = () => {
+      const utterance = new SpeechSynthesisUtterance(chunkText);
+      utterance.rate = rate;
+
+      // Set voice if available
+      if (voice) {
+        utterance.voice = voice;
+      }
+
+      // Clear any existing start timeout
+      if (startTimeoutRef.current) {
+        clearTimeout(startTimeoutRef.current);
+        startTimeoutRef.current = null;
+      }
+
+      utterance.onstart = () => {
+        console.log("TTS: Chunk started speaking");
+        if (startTimeoutRef.current) {
+          clearTimeout(startTimeoutRef.current);
+          startTimeoutRef.current = null;
+        }
+        setIsPlaying(true);
+        setIsPaused(false);
+      };
+
+      utterance.onend = () => {
+        console.log("TTS: Chunk finished speaking");
+        if (startTimeoutRef.current) {
+          clearTimeout(startTimeoutRef.current);
+          startTimeoutRef.current = null;
+        }
+        // Move to next chunk
+        if (!isStoppedRef.current) {
+          currentChunkIndexRef.current++;
+          playNextChunkRef.current?.();
+        }
+      };
+
+      utterance.onerror = (event) => {
+        if (startTimeoutRef.current) {
+          clearTimeout(startTimeoutRef.current);
+          startTimeoutRef.current = null;
+        }
+        // Don't log "interrupted" or "canceled" errors as they're expected when stopping
+        if (event.error !== "interrupted" && event.error !== "canceled") {
+          console.error("TTS: Speech synthesis error:", event.error);
+        }
+        // On error, try to continue with next chunk (unless it was a cancel)
+        if (event.error !== "interrupted" && event.error !== "canceled") {
+          if (!isStoppedRef.current) {
+            currentChunkIndexRef.current++;
+            playNextChunkRef.current?.();
+          }
+        } else {
+          setIsPlaying(false);
+          setIsPaused(false);
+        }
+      };
+
+      utteranceRef.current = utterance;
+
+      // Speak the utterance
+      window.speechSynthesis.speak(utterance);
+
+      // Chrome/Safari bug workaround: speechSynthesis can get stuck in pending state
+      // Calling resume() helps kick-start it
+      window.speechSynthesis.resume();
+
+      // iOS workaround: onstart may not fire, so set a timeout to detect stuck state
+      if (isMobile) {
+        startTimeoutRef.current = setTimeout(() => {
+          // Check if speech actually started
+          if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
+            console.log("TTS: Mobile fallback - assuming speech started");
+            setIsPlaying(true);
+            setIsPaused(false);
+          }
+        }, 500);
+      }
+    };
+
+    // iOS needs a small delay after cancel before starting new speech
+    if (isIOS) {
+      setTimeout(startSpeaking, 100);
+    } else {
+      startSpeaking();
+    }
+  }, [rate, voice]);
+
+  // Play the next chunk in the queue
+  const playNextChunk = useCallback(() => {
+    if (isStoppedRef.current) {
+      console.log("TTS: Stopped, not playing next chunk");
+      setIsPlaying(false);
+      setIsPaused(false);
+      return;
+    }
+
+    const chunks = chunksRef.current;
+    const currentIndex = currentChunkIndexRef.current;
+
+    if (currentIndex >= chunks.length) {
+      console.log("TTS: All chunks finished");
+      setIsPlaying(false);
+      setIsPaused(false);
+      return;
+    }
+
+    console.log(`TTS: Playing chunk ${currentIndex + 1}/${chunks.length}`);
+    speakChunk(chunks[currentIndex]);
+  }, [speakChunk]);
+
+  // Keep ref updated with latest playNextChunk
+  useEffect(() => {
+    playNextChunkRef.current = playNextChunk;
+  }, [playNextChunk]);
 
   const play = useCallback(() => {
     if (!isSupported) {
@@ -93,51 +325,29 @@ export function useTextToSpeech(text: string): [TTSState, TTSControls] {
       return;
     }
 
-    // Cancel any ongoing speech
-    window.speechSynthesis.cancel();
-
-    // Create utterance with the text
-    const utterance = new SpeechSynthesisUtterance(textRef.current);
-    utterance.rate = rate;
-
-    // Set voice if available
-    if (voice) {
-      utterance.voice = voice;
+    // Unlock audio on mobile (must be called from user gesture)
+    if (isMobile) {
+      unlockAudio();
     }
 
-    utterance.onstart = () => {
-      console.log("TTS: Started speaking");
-      setIsPlaying(true);
-      setIsPaused(false);
-    };
+    // Cancel any ongoing speech
+    window.speechSynthesis.cancel();
+    isStoppedRef.current = false;
 
-    utterance.onend = () => {
-      console.log("TTS: Finished speaking");
-      setIsPlaying(false);
-      setIsPaused(false);
-    };
+    // Split text into chunks for better mobile compatibility
+    const chunks = splitTextIntoChunks(textRef.current, MAX_UTTERANCE_LENGTH);
+    chunksRef.current = chunks;
+    currentChunkIndexRef.current = 0;
 
-    utterance.onerror = (event) => {
-      // Don't log "interrupted" errors as they're expected when stopping/restarting
-      if (event.error !== "interrupted") {
-        console.error("TTS: Speech synthesis error:", event.error);
-      }
-      setIsPlaying(false);
-      setIsPaused(false);
-    };
+    console.log(`TTS: Split text into ${chunks.length} chunks (mobile: ${isMobile}, iOS: ${isIOS})`);
 
-    utteranceRef.current = utterance;
-
-    // Speak the utterance
-    window.speechSynthesis.speak(utterance);
-
-    // Chrome bug workaround: speechSynthesis can get stuck in pending state
-    // Calling resume() helps kick-start it
-    window.speechSynthesis.resume();
-
-    // Set playing state immediately and rely on onstart/onerror to correct it if needed
+    // Set playing state immediately
     setIsPlaying(true);
-  }, [isSupported, rate, voice]);
+    setIsPaused(false);
+
+    // Start playing first chunk
+    playNextChunk();
+  }, [isSupported, playNextChunk]);
 
   const pause = useCallback(() => {
     if (!isSupported) return;
@@ -167,6 +377,11 @@ export function useTextToSpeech(text: string): [TTSState, TTSControls] {
 
   const stop = useCallback(() => {
     if (!isSupported) return;
+    isStoppedRef.current = true;
+    if (startTimeoutRef.current) {
+      clearTimeout(startTimeoutRef.current);
+      startTimeoutRef.current = null;
+    }
     window.speechSynthesis.cancel();
     setIsPlaying(false);
     setIsPaused(false);

--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -29,8 +29,9 @@ const MAX_UTTERANCE_LENGTH = isMobile ? 2000 : 10000;
 /**
  * Split text into chunks for better mobile compatibility.
  * Tries to split on sentence boundaries to maintain natural speech flow.
+ * Exported for testing.
  */
-function splitTextIntoChunks(text: string, maxLength: number): string[] {
+export function splitTextIntoChunks(text: string, maxLength: number): string[] {
   if (text.length <= maxLength) {
     return [text];
   }


### PR DESCRIPTION
## Summary
Enhanced the `useTextToSpeech` hook to provide better compatibility with mobile browsers and iOS devices by implementing text chunking, audio context unlocking, and platform-specific workarounds.

## Key Changes

- **Text Chunking**: Added `splitTextIntoChunks()` function that intelligently splits long text into smaller chunks (2000 chars on mobile, 10000 on desktop) while preserving sentence boundaries. This prevents mobile browsers from struggling with long utterances.

- **Audio Unlocking**: Implemented `unlockAudio()` function that creates and plays a silent audio buffer to unlock audio playback on mobile browsers. This must be called from a user gesture (click/tap) handler.

- **Platform Detection**: Added detection for mobile and iOS devices to apply targeted workarounds:
  - iOS: Adds 100ms delay after canceling speech before starting new utterance
  - Mobile: Uses shorter max utterance length and implements fallback timeout for `onstart` event

- **Improved State Management**: 
  - Refactored speech playback to use chunk-based queue system with `playNextChunk()` callback
  - Added refs to track stopped state, current chunk index, and pending timeouts
  - Properly clean up timeouts on unmount and stop

- **Better Error Handling**: Enhanced error handling to distinguish between expected interruptions/cancellations and actual errors, with graceful fallback to next chunk on non-fatal errors.

- **Chrome Bug Workaround**: Maintained existing `speechSynthesis.resume()` call to handle Chrome's pending state issue.

- **Performance**: Moved browser support check to module level to avoid repeated checks on every render.

## Implementation Details

The hook now maintains a queue of text chunks and plays them sequentially. Each chunk has its own `SpeechSynthesisUtterance` with proper event handlers (`onstart`, `onend`, `onerror`) that trigger playback of the next chunk. Mobile devices get additional safeguards including a 500ms timeout fallback for the `onstart` event, which may not fire reliably on some iOS devices.

https://claude.ai/code/session_011vgVcFAtjryEVXAaAnq2tc