### PR TITLE
Persist article storage metrics during ingestion

### DIFF
--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -13,6 +13,8 @@ export type Article = {
   readTimeMinutes: number | null;
   progress: number;
   summary?: string; // AI-generated summary of the article
+  assetCount?: number; // Number of files stored for this article
+  sizeBytes?: number; // Total storage size in bytes across all files
   // publishedTime: string | null;
 };
 


### PR DESCRIPTION
## Summary
This PR optimizes storage size calculation by persisting asset count and total size information during article ingestion, eliminating the need for expensive on-demand calculations in most cases.

## Key Changes
- **Added storage metrics to Article model**: New optional fields `assetCount` and `sizeBytes` to track persisted storage information
- **Updated ingestion pipeline**: Modified `ingestHtml()`, `ingestPdf()`, and `ingestImage()` to calculate and persist asset counts and total sizes during the ingestion process
- **Enhanced image processing**: Modified `downloadAndResizeImages()` to return detailed metrics (successful downloads, saved bytes, file count) instead of just a count
- **Optimized ArticleScreen display logic**: Updated storage size display to prefer persisted metrics from the article object, falling back to on-demand calculation only when metrics are unavailable
- **Conditional calculation**: Added checks in two locations to skip expensive `calculateArticleStorageSize()` calls when persisted metrics are already available

## Implementation Details
- Storage size calculation now happens during ingestion when all file data is readily available, improving performance
- The on-demand calculation remains as a fallback for articles ingested before this change or in edge cases
- Asset counts include base files (HTML, metadata, logs) plus image/thumbnail resources
- Size calculations account for all stored files: rendered HTML, raw HTML, fetch logs, article metadata, and media resources

https://claude.ai/code/session_011h8i7BVMqrpsxkER9yKVSF