### PR TITLE
Add dark mode support to article rendering and UI components

### DIFF
--- a/shared/static/web.css
+++ b/shared/static/web.css
@@ -120,7 +120,7 @@ pre {
 
 /* Code blocks (for markdown code) */
 code {
-    background-color: #f5f5f5;
+    background-color: rgba(0, 0, 0, 0.06);
     padding: 0.2em 0.4em;
     border-radius: 3px;
     font-family: 'Courier New', Consolas, monospace;
@@ -131,16 +131,17 @@ pre code {
     display: block;
     padding: 1em;
     overflow-x: auto;
-    background-color: #f5f5f5;
+    background-color: rgba(0, 0, 0, 0.06);
     border-radius: 5px;
 }
 
 /* Blockquotes (for markdown quotes) */
 blockquote {
-    border-left: 3px solid #ccc;
+    border-left: 3px solid rgba(128, 128, 128, 0.4);
     margin-left: 0;
     padding-left: 1em;
-    color: #666;
+    color: inherit;
+    opacity: 0.75;
     font-style: italic;
 }
 
@@ -152,12 +153,13 @@ table {
 }
 
 th, td {
-    border: 1px solid #ddd;
+    border: 1px solid rgba(128, 128, 128, 0.3);
     padding: 0.5em;
     text-align: left;
 }
 
 th {
-    background-color: #f5f5f5;
+    background-color: rgba(0, 0, 0, 0.06);
     font-weight: bold;
 }
+

--- a/src/components/ArticleComponent.tsx
+++ b/src/components/ArticleComponent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Container } from "@mui/material";
+import { Box, Container, useTheme } from "@mui/material";
 
 interface ArticleComponentProps {
   html: string;
@@ -7,6 +7,9 @@ interface ArticleComponentProps {
 }
 
 const ArticleComponent: React.FC<ArticleComponentProps> = ({ html, fontSize }) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+
   return (
     <Container
       maxWidth="md"
@@ -15,14 +18,30 @@ const ArticleComponent: React.FC<ArticleComponentProps> = ({ html, fontSize }) =
         mt: 1,
         mb: 4,
         p: "12px",
-        // paddingTop: "0px",
-        // mx: "auto",
-        // display: "block",
       }}
     >
       <Box
         sx={{
           fontSize: fontSize,
+          color: "text.primary",
+          "& a": {
+            color: "primary.main",
+          },
+          "& code": {
+            backgroundColor: isDark ? "rgba(255,255,255,0.1)" : undefined,
+          },
+          "& pre code": {
+            backgroundColor: isDark ? "rgba(255,255,255,0.1)" : undefined,
+          },
+          "& blockquote": {
+            borderLeftColor: isDark ? "rgba(255,255,255,0.3)" : undefined,
+          },
+          "& th, & td": {
+            borderColor: isDark ? "rgba(255,255,255,0.2)" : undefined,
+          },
+          "& th": {
+            backgroundColor: isDark ? "rgba(255,255,255,0.1)" : undefined,
+          },
         }}
         dangerouslySetInnerHTML={{ __html: html }}
       />

--- a/src/components/CorsTestScreen.tsx
+++ b/src/components/CorsTestScreen.tsx
@@ -11,7 +11,8 @@ export default function CorsTestScreen() {
         sx={{
           width: "100%",
           height: "calc(100vh - 100px)",
-          border: "1px solid #ccc",
+          border: 1,
+          borderColor: "divider",
         }}
       >
         <iframe

--- a/src/components/PreferenceScreen.tsx
+++ b/src/components/PreferenceScreen.tsx
@@ -576,7 +576,9 @@ export default function PreferencesScreen() {
                 style={{
                   padding: "8px",
                   borderRadius: "4px",
-                  border: "1px solid #ccc",
+                  border: "1px solid rgba(128, 128, 128, 0.4)",
+                  backgroundColor: "inherit",
+                  color: "inherit",
                   fontSize: "14px",
                   minWidth: "150px",
                 }}
@@ -621,7 +623,9 @@ export default function PreferencesScreen() {
                   style={{
                     padding: "8px",
                     borderRadius: "4px",
-                    border: "1px solid #ccc",
+                    border: "1px solid rgba(128, 128, 128, 0.4)",
+                  backgroundColor: "inherit",
+                  color: "inherit",
                     fontSize: "14px",
                     minWidth: "120px",
                   }}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { DefaultCatchBoundary } from "~/components/DefaultCatchBoundary";
 import { NotFound } from "~/components/NotFound";
 
-import { ThemeProvider, CssBaseline } from "@mui/material";
+import { ThemeProvider, CssBaseline, Box } from "@mui/material";
 import { RemoteStorageProvider } from "~/components/RemoteStorageProvider";
 import { SyncStatusProvider } from "~/components/SyncStatusProvider";
 import { PWARegister } from "~/components/PWARegister";
@@ -69,7 +69,7 @@ function UrlPatternMatcher() {
             style={{
               display: "inline-block",
               padding: "12px 24px",
-              backgroundColor: "#1976d2",
+              backgroundColor: "var(--savr-primary, #1976d2)",
               color: "white",
               textDecoration: "none",
               borderRadius: "4px",
@@ -82,7 +82,7 @@ function UrlPatternMatcher() {
             style={{
               marginTop: "2rem",
               padding: "1rem",
-              backgroundColor: "#f5f5f5",
+              backgroundColor: "rgba(128, 128, 128, 0.1)",
               borderRadius: "4px",
             }}
           >
@@ -145,11 +145,11 @@ function RootComponent() {
         <SyncStatusProvider>
           <ThemeProvider theme={appTheme}>
             <CssBaseline enableColorScheme />
-            <div style={{ minHeight: "100vh", backgroundColor: "background.default" }}>
+            <Box sx={{ minHeight: "100vh", bgcolor: "background.default" }}>
               <Outlet />
               <TanStackRouterDevtools position="bottom-left" />
               <PWARegister />
-            </div>
+            </Box>
           </ThemeProvider>
         </SyncStatusProvider>
       </RemoteStorageProvider>


### PR DESCRIPTION
## Summary
This PR adds comprehensive dark mode support to the article component and various UI elements throughout the application. The changes ensure that rendered markdown content (code blocks, blockquotes, tables, links) and form inputs properly adapt to both light and dark themes.

## Key Changes

- **ArticleComponent**: Added theme-aware styling for markdown elements
  - Links now use `primary.main` color
  - Code blocks and inline code get semi-transparent backgrounds in dark mode
  - Blockquotes, table borders, and table headers adapt to theme
  - Text color defaults to `text.primary` for proper contrast

- **Global Styles (web.css)**: Updated color values to be theme-agnostic
  - Changed hardcoded colors (#f5f5f5, #ccc, #ddd, #666) to semantic rgba values
  - Code block backgrounds now use `rgba(0, 0, 0, 0.06)` for light mode compatibility
  - Blockquote borders and table borders use `rgba(128, 128, 128, ...)` for neutral appearance
  - Blockquote text now inherits color with reduced opacity instead of hardcoded gray

- **Root Layout**: Improved theme integration
  - Replaced inline div with MUI `Box` component for proper theme support
  - Updated background color to use theme's `background.default`
  - Fixed button styling to use CSS variable fallback for primary color

- **PreferenceScreen**: Enhanced form inputs for dark mode
  - Updated select/input borders to use semantic rgba colors
  - Added `backgroundColor: "inherit"` and `color: "inherit"` for proper theme adaptation

- **CorsTestScreen**: Improved iframe border styling
  - Replaced hardcoded border color with MUI's `divider` color token

## Implementation Details

The changes leverage MUI's `useTheme()` hook to detect dark mode and apply conditional styling. Hardcoded color values have been replaced with either MUI theme tokens or semantic rgba values that work across both light and dark themes. This ensures consistent visual appearance and proper contrast ratios in both modes.

https://claude.ai/code/session_01AqKqRsvFBQwEYSU3wPSZ9Y