### PR TITLE
Consolidate reading styles into unified drawer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <link rel="stylesheet" href="/web.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Lato:wght@400;700&family=Lora:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Savr - Save Articles for Reading</title>
   </head>

--- a/public/web.css
+++ b/public/web.css
@@ -6,7 +6,7 @@
     font-family: Helvetica, Arial, sans-serif;
 }
 #savr-content {
-    font-family: Georgia, 'Times New Roman', Times, serif;
+    font-family: var(--savr-font-family, Georgia, 'Times New Roman', Times, serif);
 }
 #savr-metadata {
     text-align: center;

--- a/src/components/ArticleComponent.tsx
+++ b/src/components/ArticleComponent.tsx
@@ -5,9 +5,10 @@ import { Box, Container, useTheme } from "@mui/material";
 interface ArticleComponentProps {
   html: string;
   fontSize: number;
+  fontFamily?: string;
 }
 
-const ArticleComponent: React.FC<ArticleComponentProps> = ({ html, fontSize }) => {
+const ArticleComponent: React.FC<ArticleComponentProps> = ({ html, fontSize, fontFamily }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
 
@@ -24,6 +25,7 @@ const ArticleComponent: React.FC<ArticleComponentProps> = ({ html, fontSize }) =
       <Box
         sx={{
           fontSize: fontSize,
+          fontFamily: fontFamily,
           color: "text.primary",
           "& h1": { textAlign: "center" },
           "& #savr-metadata": { textAlign: "center" },

--- a/src/components/ArticleComponent.tsx
+++ b/src/components/ArticleComponent.tsx
@@ -20,14 +20,13 @@ const ArticleComponent: React.FC<ArticleComponentProps> = ({ html, fontSize, fon
         mt: 1,
         mb: 4,
         p: "12px",
-      }}
+        "--savr-font-family": fontFamily ?? "Georgia, 'Times New Roman', Times, serif",
+      } as React.CSSProperties}
     >
       <Box
         sx={{
           fontSize: fontSize,
-          fontFamily: fontFamily,
           color: "text.primary",
-          "& *:not(code):not(pre):not(pre *)": { fontFamily: fontFamily ?? "inherit" },
           "& h1": { textAlign: "center" },
           "& #savr-metadata": { textAlign: "center" },
           "& a": {

--- a/src/components/ArticleComponent.tsx
+++ b/src/components/ArticleComponent.tsx
@@ -27,6 +27,7 @@ const ArticleComponent: React.FC<ArticleComponentProps> = ({ html, fontSize, fon
           fontSize: fontSize,
           fontFamily: fontFamily,
           color: "text.primary",
+          "& *:not(code):not(pre):not(pre *)": { fontFamily: fontFamily ?? "inherit" },
           "& h1": { textAlign: "center" },
           "& #savr-metadata": { textAlign: "center" },
           "& a": {

--- a/src/components/ArticleScreen.tsx
+++ b/src/components/ArticleScreen.tsx
@@ -20,6 +20,10 @@ import {
   LinearProgress,
   CircularProgress,
   Collapse,
+  Select,
+  MenuItem as SelectMenuItem,
+  FormControl,
+  InputLabel,
 } from "@mui/material";
 // import useScrollTrigger from "@mui/material/useScrollTrigger";
 import {
@@ -56,7 +60,17 @@ import { useSnackbar } from "notistack";
 import ArticleComponent from "./ArticleComponent";
 import TextToSpeechDrawer from "./TextToSpeechDrawer";
 import { useTextToSpeech } from "~/hooks/useTextToSpeech";
-import { getFontSizeFromCookie, setFontSizeInCookie, getThemeFromCookie, setThemeInCookie, ThemeMode } from "~/utils/cookies";
+import {
+  getFontSizeFromCookie,
+  setFontSizeInCookie,
+  getThemeFromCookie,
+  setThemeInCookie,
+  ThemeMode,
+  getFontFamilyFromCookie,
+  setFontFamilyInCookie,
+  FONT_FAMILY_OPTIONS,
+  FontFamily,
+} from "~/utils/cookies";
 import { getHeaderHidingFromCookie } from "~/utils/cookies";
 import { getFilePathContent, getFilePathRaw, getFileFetchLog, getFilePathPdf, getFilePathImage, mimeToExt } from "../../lib/src/lib";
 import { ReadingSessionTracker } from "../../lib/src/readingSpeed";
@@ -113,6 +127,8 @@ export default function ArticleScreen(_props: Props) {
   const [summaryDrawerOpen, setSummaryDrawerOpen] = useState(false);
   const [stylesDrawerOpen, setStylesDrawerOpen] = useState(false);
   const [currentTheme, setCurrentTheme] = useState<ThemeMode>(() => getThemeFromCookie());
+  const [fontFamily, setFontFamily] = useState<FontFamily>(() => getFontFamilyFromCookie());
+  const currentFontCss = FONT_FAMILY_OPTIONS.find((o) => o.value === fontFamily)?.css;
   const [_summaryProgress, setSummaryProgress] = useState<SummarizationProgress | null>(null);
   const [isSummarizing, setIsSummarizing] = useState(false);
 
@@ -1009,7 +1025,7 @@ export default function ArticleScreen(_props: Props) {
             />
           </Box>
         ) : (
-          <ArticleComponent html={htmlWithSummaryLink} fontSize={fontSize} />
+          <ArticleComponent html={htmlWithSummaryLink} fontSize={fontSize} fontFamily={currentFontCss} />
         )}
       </Box>
 
@@ -1277,6 +1293,28 @@ export default function ArticleScreen(_props: Props) {
             >
               <AddIcon />
             </IconButton>
+          </Box>
+
+          {/* Font family */}
+          <Box sx={{ pt: 2, borderTop: "1px solid", borderColor: "divider", mt: 2 }}>
+            <FormControl fullWidth size="small">
+              <InputLabel>Font</InputLabel>
+              <Select
+                value={fontFamily}
+                label="Font"
+                onChange={(e) => {
+                  const val = e.target.value as FontFamily;
+                  setFontFamily(val);
+                  setFontFamilyInCookie(val);
+                }}
+              >
+                {FONT_FAMILY_OPTIONS.map((opt) => (
+                  <SelectMenuItem key={opt.value} value={opt.value} sx={{ fontFamily: opt.css }}>
+                    {opt.label}
+                  </SelectMenuItem>
+                ))}
+              </Select>
+            </FormControl>
           </Box>
         </Box>
       </Drawer>

--- a/src/components/ArticleScreen.tsx
+++ b/src/components/ArticleScreen.tsx
@@ -42,6 +42,10 @@ import {
   ExpandLess as ExpandLessIcon,
   Star as StarIcon,
   StarBorder as StarBorderIcon,
+  FormatSize as FormatSizeIcon,
+  LightMode as LightModeIcon,
+  DarkMode as DarkModeIcon,
+  SettingsBrightness as SettingsBrightnessIcon,
 } from "@mui/icons-material";
 import { Route } from "~/routes/article.$slug";
 import { useRemoteStorage } from "./RemoteStorageProvider";
@@ -50,10 +54,9 @@ import { Article } from "../../lib/src/models";
 import { removeArticle, patchArticleMetadata } from "~/utils/article/tools";
 import { useSnackbar } from "notistack";
 import ArticleComponent from "./ArticleComponent";
-import { CookieThemeToggle } from "./CookieThemeToggle";
 import TextToSpeechDrawer from "./TextToSpeechDrawer";
 import { useTextToSpeech } from "~/hooks/useTextToSpeech";
-import { getFontSizeFromCookie, setFontSizeInCookie } from "~/utils/cookies";
+import { getFontSizeFromCookie, setFontSizeInCookie, getThemeFromCookie, setThemeInCookie, ThemeMode } from "~/utils/cookies";
 import { getHeaderHidingFromCookie } from "~/utils/cookies";
 import { getFilePathContent, getFilePathRaw, getFileFetchLog, getFilePathPdf, getFilePathImage, mimeToExt } from "../../lib/src/lib";
 import { ReadingSessionTracker } from "../../lib/src/readingSpeed";
@@ -108,6 +111,8 @@ export default function ArticleScreen(_props: Props) {
   const [refetchPercent, setRefetchPercent] = useState<number>(0);
   const [refetchStatus, setRefetchStatus] = useState<string | null>(null);
   const [summaryDrawerOpen, setSummaryDrawerOpen] = useState(false);
+  const [stylesDrawerOpen, setStylesDrawerOpen] = useState(false);
+  const [currentTheme, setCurrentTheme] = useState<ThemeMode>(() => getThemeFromCookie());
   const [_summaryProgress, setSummaryProgress] = useState<SummarizationProgress | null>(null);
   const [isSummarizing, setIsSummarizing] = useState(false);
 
@@ -799,33 +804,14 @@ export default function ArticleScreen(_props: Props) {
             {/* {article.title} */}
           </Typography>
 
-          <Tooltip title="Increase font size">
+          <Tooltip title="Reading styles">
             <IconButton
               color="inherit"
-              onClick={() => {
-                const newSize = fontSize + 2;
-                setFontSize(newSize);
-                setFontSizeInCookie(newSize);
-              }}
+              onClick={() => setStylesDrawerOpen(true)}
             >
-              <AddIcon />
+              <FormatSizeIcon />
             </IconButton>
           </Tooltip>
-
-          <Tooltip title="Decrease font size">
-            <IconButton
-              color="inherit"
-              onClick={() => {
-                const newSize = fontSize - 2;
-                setFontSize(newSize);
-                setFontSizeInCookie(newSize);
-              }}
-            >
-              <RemoveIcon />
-            </IconButton>
-          </Tooltip>
-
-          <CookieThemeToggle size="small" />
 
           <Tooltip title="Listen to article">
             <IconButton
@@ -1176,6 +1162,122 @@ export default function ArticleScreen(_props: Props) {
             </Typography>
           )}
           <LinearProgress variant="determinate" value={refetchPercent} />
+        </Box>
+      </Drawer>
+
+      {/* Styles Drawer */}
+      <Drawer
+        anchor="bottom"
+        open={stylesDrawerOpen}
+        onClose={() => setStylesDrawerOpen(false)}
+        PaperProps={{
+          sx: {
+            borderTopLeftRadius: 16,
+            borderTopRightRadius: 16,
+            bgcolor: "background.paper",
+            color: "text.primary",
+          },
+        }}
+      >
+        <Box sx={{ p: 3 }}>
+          <Typography variant="subtitle1" sx={{ mb: 2, fontWeight: 600 }}>
+            Reading styles
+          </Typography>
+
+          {/* Theme mode */}
+          <Box sx={{ display: "flex", gap: 2, mb: 3, justifyContent: "center" }}>
+            {(["light", "dark", "system"] as ThemeMode[]).map((mode) => {
+              const selected = currentTheme === mode;
+              const icon =
+                mode === "light" ? (
+                  <LightModeIcon />
+                ) : mode === "dark" ? (
+                  <DarkModeIcon />
+                ) : (
+                  <SettingsBrightnessIcon />
+                );
+              const label = mode.charAt(0).toUpperCase() + mode.slice(1);
+              return (
+                <Box
+                  key={mode}
+                  onClick={() => {
+                    if (currentTheme !== mode) {
+                      setThemeInCookie(mode);
+                      setCurrentTheme(mode);
+                      window.dispatchEvent(new CustomEvent("themeChanged"));
+                    }
+                  }}
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 0.5,
+                    cursor: "pointer",
+                    flex: 1,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 56,
+                      height: 56,
+                      borderRadius: "50%",
+                      border: selected ? "2px solid" : "2px solid",
+                      borderColor: selected ? "primary.main" : "divider",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      bgcolor: selected ? "primary.main" : "transparent",
+                      color: selected ? "primary.contrastText" : "text.secondary",
+                      transition: "all 0.2s ease-in-out",
+                    }}
+                  >
+                    {icon}
+                  </Box>
+                  <Typography
+                    variant="caption"
+                    sx={{ color: selected ? "primary.main" : "text.secondary" }}
+                  >
+                    {label}
+                  </Typography>
+                </Box>
+              );
+            })}
+          </Box>
+
+          {/* Font size */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 2,
+              pt: 2,
+              borderTop: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <IconButton
+              onClick={() => {
+                const newSize = Math.max(12, fontSize - 2);
+                setFontSize(newSize);
+                setFontSizeInCookie(newSize);
+              }}
+            >
+              <RemoveIcon />
+            </IconButton>
+            <Typography sx={{ minWidth: 60, textAlign: "center", fontSize }}>
+              A
+            </Typography>
+            <IconButton
+              onClick={() => {
+                const newSize = Math.min(32, fontSize + 2);
+                setFontSize(newSize);
+                setFontSizeInCookie(newSize);
+              }}
+            >
+              <AddIcon />
+            </IconButton>
+          </Box>
         </Box>
       </Drawer>
 

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -5,6 +5,7 @@ export type ThemeMode = "light" | "dark" | "system";
 
 export const THEME_COOKIE_NAME = "savr-theme";
 export const FONT_SIZE_COOKIE_NAME = "savr-font-size";
+export const FONT_FAMILY_COOKIE_NAME = "savr-font-family";
 export const CORS_PROXY_COOKIE_NAME = "savr-cors-proxy";
 export const HEADER_HIDING_COOKIE_NAME = "savr-header-hiding";
 export const AFTER_EXTERNAL_SAVE_COOKIE_NAME = "savr-after-external-save";
@@ -170,6 +171,34 @@ export const setCorsProxyInCookie = (corsProxy: string | null): void => {
     // Remove cookie if value is null or empty
     document.cookie = `${CORS_PROXY_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
   }
+};
+
+export type FontFamily = "sans" | "serif" | "humanist" | "mono";
+
+export const FONT_FAMILY_OPTIONS: { value: FontFamily; label: string; css: string }[] = [
+  { value: "sans", label: "Sans (Inter)", css: "'Inter', sans-serif" },
+  { value: "serif", label: "Serif (Lora)", css: "'Lora', Georgia, serif" },
+  { value: "humanist", label: "Humanist (Lato)", css: "'Lato', sans-serif" },
+  { value: "mono", label: "Mono", css: "monospace" },
+];
+
+export const getFontFamilyFromCookie = (): FontFamily => {
+  if (typeof document === "undefined") return "sans";
+
+  const cookies = document.cookie.split(";");
+  const cookie = cookies.find((c) => c.trim().startsWith(`${FONT_FAMILY_COOKIE_NAME}=`));
+  if (cookie) {
+    const value = cookie.split("=")[1].trim() as FontFamily;
+    if (FONT_FAMILY_OPTIONS.some((o) => o.value === value)) return value;
+  }
+  return "sans";
+};
+
+export const setFontFamilyInCookie = (font: FontFamily): void => {
+  if (typeof document === "undefined") return;
+  const expires = new Date();
+  expires.setFullYear(expires.getFullYear() + 1);
+  document.cookie = `${FONT_FAMILY_COOKIE_NAME}=${font}; expires=${expires.toUTCString()}; path=/`;
 };
 
 // Set font size in cookie


### PR DESCRIPTION
## Summary
Refactored the article reading interface to consolidate font size and theme controls into a single "Reading styles" drawer, improving UX by grouping related settings together.

## Key Changes
- **Replaced individual toolbar buttons** with a single "Reading styles" button (FormatSizeIcon) that opens a bottom drawer
- **Removed CookieThemeToggle component** from the header and integrated theme selection into the new styles drawer
- **Added theme mode selection UI** with three options (Light, Dark, System) displayed as circular icon buttons with visual feedback
- **Reorganized font size controls** into the drawer with decrease/increase buttons and a preview letter "A"
- **Added theme persistence** by importing and using `getThemeFromCookie`, `setThemeInCookie`, and `ThemeMode` utilities
- **Implemented theme change event** that dispatches a custom "themeChanged" event when the user selects a different theme mode
- **Added bounds checking** for font size adjustments (min: 12px, max: 32px)
- **Imported additional Material-UI icons** for theme modes (LightModeIcon, DarkModeIcon, SettingsBrightnessIcon)

## Implementation Details
- The styles drawer uses a bottom anchor with rounded top corners for a modern appearance
- Theme selection displays visual feedback with a colored circular border and filled background for the selected mode
- Font size adjustment includes a live preview with the letter "A" displayed at the current size
- State management includes `stylesDrawerOpen` for drawer visibility and `currentTheme` for tracking the current theme mode
- Theme changes are persisted to cookies and trigger a custom event for global theme updates

https://claude.ai/code/session_01UvzZx1E7iP1DMu22xLEY7n