### PR TITLE
Handle <picture>/<source> elements in image extraction

### DIFF
--- a/docs/readability-lazy-picture-workaround.md
+++ b/docs/readability-lazy-picture-workaround.md
@@ -1,0 +1,85 @@
+# Workaround: recovering lazy-loaded `<picture>` images before Readability
+
+## TL;DR
+
+`hoistPictureSources()` in `lib/src/ingestion.ts` lifts the largest `<source srcset>`
+URL onto a srcless `<img>` **before** Readability parses the document. Without it,
+articles from Medium (and other sites using the same pattern) come through with **no
+images at all**. If/when upstream Readability learns to recover these images, this
+workaround can be removed.
+
+## The symptom
+
+Fetching e.g. <https://medium.com/airbnb-engineering/rethinking-text-resizing-on-web-1047b12d2881>
+produced an article with the body images missing — only the author avatar survived.
+
+## Why it happens
+
+Medium (and similar sites) render every article image as a lazy-loaded `<picture>`:
+
+```html
+<figure>
+  <picture>
+    <source srcSet="https://miro.medium.com/v2/resize:fit:640/.../1*x.jpeg 640w,
+                    https://miro.medium.com/v2/resize:fit:1400/.../1*x.jpeg 1400w" ...>
+    <img alt="..." width="700" height="467" loading="eager">   <!-- NO src -->
+  </picture>
+</figure>
+```
+
+Two things combine to defeat extraction:
+
+1. The `<img>` has **no `src` and no `srcset`** — Medium populates it via client-side
+   JS on scroll. The real URL lives only in the sibling `<source srcSet>`.
+2. **Readability runs before our image extraction.** It discards the "empty" `<img>`
+   (and its `<picture>`/`<source>`) during the grab/clean pass because there's nothing
+   to score. By the time `extractImageUrls` runs, the body images are already gone.
+
+Verified directly against the live HTML (fetched through the app's CORS proxy):
+Readability returned **0 body images**; after `hoistPictureSources` it preserves them.
+
+## Why Readability doesn't handle it
+
+This is a long-standing **gap**, not a deliberate choice.
+
+- Readability has lazy-image handling — `_fixLazyImages` (added in
+  [PR #590](https://github.com/mozilla/readability/pull/590), the "Kinja sites" fix,
+  [commit 52ab9b5](https://github.com/mozilla/readability/commit/52ab9b5c8916c306a47b2119270dcdabebf9d203)).
+  But it only inspects an **element's own attributes**, looking for `data-src` /
+  `data-srcset`-style values. It **never reads the `srcset` off child `<source>`
+  elements** inside a `<picture>`. The only `<source>` handling is `_fixRelativeUris`,
+  which merely rewrites relative URLs to absolute — it does not hoist anything.
+- `_fixLazyImages` was scoped to the convention common circa 2018: the real URL sits in
+  a `data-*` attribute **on the `<img>` itself**. Medium's variant (empty `<img>` +
+  real URL only on `<source>`, hydrated by JS) was never covered, and no upstream
+  issue/PR addresses the source-only `<picture>` case specifically.
+- The broader "srcset/lazy images dropped" problem has been **open and unassigned since
+  2017**: [Bugzilla 1355164](https://bugzilla.mozilla.org/show_bug.cgi?id=1355164).
+  Related issues: [#657](https://github.com/mozilla/readability/issues/657)
+  (recognize `data-src`/`data-srcset` without image extensions),
+  [#544](https://github.com/mozilla/readability/issues/544) (make lazy detection optional).
+
+So the historically dominant lazyload convention (URL in a `data-*` attr on the `<img>`)
+*is* handled; the source-only `<picture>` pattern is the unaddressed edge.
+
+## How our fix works (two parts)
+
+1. **`hoistPictureSources(doc)`** — runs in `readabilityToArticle` *before*
+   `new Readability(...)`. For each `<picture>` whose `<img>` lacks a `src`, it copies
+   the largest `<source>` srcset URL onto the `<img>`, so Readability keeps the image.
+2. **`extractImageUrls(doc, url)`** — runs *after* Readability, during download. For
+   images inside a `<picture>` it falls back to the `<source>` srcset when the `<img>`
+   still has none, then **strips the `<source>` siblings** so the rendered article uses
+   the downloaded local copy (the browser otherwise gives `<source>` precedence over
+   `<img src>` and would re-fetch the remote original).
+
+## When can this be removed?
+
+If a future `@mozilla/readability` recovers source-only `<picture>` images on its own
+(watch [Bugzilla 1355164](https://bugzilla.mozilla.org/show_bug.cgi?id=1355164) and
+`_fixLazyImages`), `hoistPictureSources` becomes redundant and can be dropped. The
+`<source>`-stripping in `extractImageUrls` should stay regardless, since it's about
+making the browser use our downloaded copies rather than about Readability.
+
+Tests: `lib/__tests__/ingestion-srcset.test.ts` (`hoistPictureSources` and the
+`<picture>`/`<source>` extraction cases).

--- a/lib/__tests__/ingestion-srcset.test.ts
+++ b/lib/__tests__/ingestion-srcset.test.ts
@@ -1,4 +1,4 @@
-import { getLargestImageFromSrcset } from "../src/ingestion";
+import { getLargestImageFromSrcset, extractImageUrls } from "../src/ingestion";
 
 describe("ingestion.ts - srcset handling", () => {
   describe("getLargestImageFromSrcset", () => {
@@ -137,6 +137,85 @@ describe("ingestion.ts - srcset handling", () => {
 
       // After processing, both should be removed
       // This would be tested through the full ingestion flow
+    });
+  });
+
+  describe("<picture>/<source> handling", () => {
+    beforeAll(() => {
+      (global as any).DOMParser = class DOMParser {
+        parseFromString(html: string, _contentType: string): Document {
+          const parser = new (require("jsdom").JSDOM)(html);
+          return parser.window.document;
+        }
+      };
+    });
+
+    const parse = (html: string): Document =>
+      new (global as any).DOMParser().parseFromString(html, "text/html");
+
+    it("removes <source> elements so the rewritten <img src> is used", async () => {
+      // Medium-style markup: the real image lives on the <img>, but the
+      // <picture>'s <source> would otherwise override it in the browser.
+      const doc = parse(`
+        <html><body>
+          <picture>
+            <source type="image/webp" srcset="https://miro.medium.com/v2/resize:fit:1400/format:webp/1*abc.png 1400w">
+            <img src="https://miro.medium.com/v2/resize:fit:700/1*abc.png" alt="hero">
+          </picture>
+        </body></html>
+      `);
+
+      const result = await extractImageUrls(doc, "https://medium.com/some-article");
+
+      expect(doc.querySelectorAll("source").length).toBe(0);
+      expect(result.length).toBe(1);
+    });
+
+    it("falls back to the largest <source> srcset when the <img> has none", async () => {
+      const doc = parse(`
+        <html><body>
+          <picture>
+            <source srcset="https://example.com/small.jpg 640w, https://example.com/large.jpg 1400w">
+            <img alt="hero">
+          </picture>
+        </body></html>
+      `);
+
+      const result = await extractImageUrls(doc, "https://example.com/article");
+
+      expect(result[0][0]).toBe("https://example.com/large.jpg");
+      expect(doc.querySelectorAll("source").length).toBe(0);
+    });
+
+    it("prefers the <img>'s own srcset over <source> elements", async () => {
+      const doc = parse(`
+        <html><body>
+          <picture>
+            <source srcset="https://example.com/source.jpg 1400w">
+            <img src="https://example.com/fallback.jpg"
+                 srcset="https://example.com/img-small.jpg 1x, https://example.com/img-large.jpg 2x">
+          </picture>
+        </body></html>
+      `);
+
+      const result = await extractImageUrls(doc, "https://example.com/article");
+
+      expect(result[0][0]).toBe("https://example.com/img-large.jpg");
+      expect(doc.querySelector("img")?.getAttribute("srcset")).toBeNull();
+      expect(doc.querySelectorAll("source").length).toBe(0);
+    });
+
+    it("leaves plain <img> elements (no <picture>) untouched", async () => {
+      const doc = parse(`
+        <html><body>
+          <img src="https://example.com/plain.jpg" alt="plain">
+        </body></html>
+      `);
+
+      const result = await extractImageUrls(doc, "https://example.com/article");
+
+      expect(result.length).toBe(1);
+      expect(result[0][0]).toBe("https://example.com/plain.jpg");
     });
   });
 });

--- a/lib/__tests__/ingestion-srcset.test.ts
+++ b/lib/__tests__/ingestion-srcset.test.ts
@@ -1,4 +1,4 @@
-import { getLargestImageFromSrcset, extractImageUrls } from "../src/ingestion";
+import { getLargestImageFromSrcset, extractImageUrls, hoistPictureSources } from "../src/ingestion";
 
 describe("ingestion.ts - srcset handling", () => {
   describe("getLargestImageFromSrcset", () => {
@@ -216,6 +216,69 @@ describe("ingestion.ts - srcset handling", () => {
 
       expect(result.length).toBe(1);
       expect(result[0][0]).toBe("https://example.com/plain.jpg");
+    });
+  });
+
+  describe("hoistPictureSources", () => {
+    beforeAll(() => {
+      (global as any).DOMParser = class DOMParser {
+        parseFromString(html: string, _contentType: string): Document {
+          const parser = new (require("jsdom").JSDOM)(html);
+          return parser.window.document;
+        }
+      };
+    });
+
+    const parse = (html: string): Document =>
+      new (global as any).DOMParser().parseFromString(html, "text/html");
+
+    it("hoists the largest <source> srcset onto a srcless <img> (Medium pattern)", () => {
+      // Medium body images carry no src; the URL lives only in <source srcSet>.
+      const doc = parse(`
+        <html><body>
+          <figure><picture>
+            <source srcset="https://miro.medium.com/v2/resize:fit:640/1*x.jpeg 640w, https://miro.medium.com/v2/resize:fit:1400/1*x.jpeg 1400w">
+            <img alt="hero" width="700" height="467">
+          </picture></figure>
+        </body></html>
+      `);
+
+      const hoisted = hoistPictureSources(doc);
+
+      expect(hoisted).toBe(1);
+      expect(doc.querySelector("img")?.getAttribute("src")).toBe(
+        "https://miro.medium.com/v2/resize:fit:1400/1*x.jpeg"
+      );
+    });
+
+    it("does not overwrite an <img> that already has a src", () => {
+      const doc = parse(`
+        <html><body>
+          <picture>
+            <source srcset="https://example.com/source.jpg 1400w">
+            <img src="https://example.com/existing.jpg" alt="hero">
+          </picture>
+        </body></html>
+      `);
+
+      const hoisted = hoistPictureSources(doc);
+
+      expect(hoisted).toBe(0);
+      expect(doc.querySelector("img")?.getAttribute("src")).toBe(
+        "https://example.com/existing.jpg"
+      );
+    });
+
+    it("ignores <picture> elements without an <img>", () => {
+      const doc = parse(`
+        <html><body>
+          <picture>
+            <source srcset="https://example.com/source.jpg 1400w">
+          </picture>
+        </body></html>
+      `);
+
+      expect(hoistPictureSources(doc)).toBe(0);
     });
   });
 });

--- a/lib/__tests__/ingestion.test.ts
+++ b/lib/__tests__/ingestion.test.ts
@@ -13,6 +13,9 @@ import { Article } from "../src/models";
       head: {
         appendChild: () => {},
       },
+      // hoistPictureSources runs before Readability; these tests don't
+      // exercise images, so an empty NodeList is sufficient.
+      querySelectorAll: () => [],
       documentElement: {
         outerHTML: string,
       },

--- a/lib/src/ingestion.ts
+++ b/lib/src/ingestion.ts
@@ -97,6 +97,34 @@ function getImageExtensionFromUrl(imgUrl: string): string {
   return "jpg";
 }
 
+// Lazy-loaded images (Medium and others) often render as a <picture> whose
+// real image URL lives only in the <source> elements, with the <img> carrying
+// no src at all. Readability discards such "empty" <img> elements before we
+// ever see them, so the article ends up with no images. Hoist the largest
+// <source> srcset onto a srcless <img> *before* Readability runs so the image
+// survives parsing; extractImageUrls then downloads it and strips the sources.
+export function hoistPictureSources(doc: Document): number {
+  let hoisted = 0;
+  doc.querySelectorAll("picture").forEach((picture) => {
+    const img = picture.querySelector("img");
+    if (!img) return;
+    // Already has a usable src — nothing to hoist.
+    if (img.getAttribute("src")) return;
+
+    for (const source of Array.from(picture.querySelectorAll("source"))) {
+      const srcset = source.getAttribute("srcset");
+      if (!srcset) continue;
+      const largest = getLargestImageFromSrcset(srcset);
+      if (largest) {
+        img.setAttribute("src", largest);
+        hoisted += 1;
+        break;
+      }
+    }
+  });
+  return hoisted;
+}
+
 export async function extractImageUrls(doc: Document, articleUrl: string | null): Promise<ImageData[]> {
   const imgElements = doc.querySelectorAll("img");
   const imgData: ImageData[] = [];
@@ -509,6 +537,10 @@ export function readabilityToArticle(
 
   // Append the base element into the head
   document.head.appendChild(base);
+
+  // Recover lazy-loaded <picture> images before Readability strips srcless
+  // <img> elements (see hoistPictureSources).
+  hoistPictureSources(document);
 
   let reader = new Readability(document);
   let readabilityResult = reader.parse();

--- a/lib/src/ingestion.ts
+++ b/lib/src/ingestion.ts
@@ -97,7 +97,7 @@ function getImageExtensionFromUrl(imgUrl: string): string {
   return "jpg";
 }
 
-async function extractImageUrls(doc: Document, articleUrl: string | null): Promise<ImageData[]> {
+export async function extractImageUrls(doc: Document, articleUrl: string | null): Promise<ImageData[]> {
   const imgElements = doc.querySelectorAll("img");
   const imgData: ImageData[] = [];
 
@@ -110,8 +110,26 @@ async function extractImageUrls(doc: Document, articleUrl: string | null): Promi
   imgElements.forEach((img) => {
     let imgUrl = img.src;
 
-    // Check if srcset exists and extract the largest image
-    const srcset = img.getAttribute('srcset');
+    // Images are frequently wrapped in <picture> with one or more <source>
+    // elements (Medium does this for every article image). The browser gives
+    // <source> precedence over the <img>'s own src/srcset, so we must (a) use
+    // a <source> srcset when the <img> has no usable srcset of its own, and
+    // (b) strip the <source> elements afterward. Otherwise the rendered
+    // article keeps loading the original remote images and ignores the local
+    // copies we write into <img src> below.
+    const picture = img.closest("picture");
+
+    let srcset = img.getAttribute("srcset");
+    if (!srcset && picture) {
+      for (const source of Array.from(picture.querySelectorAll("source"))) {
+        const sourceSrcset = source.getAttribute("srcset");
+        if (sourceSrcset) {
+          srcset = sourceSrcset;
+          break;
+        }
+      }
+    }
+
     if (srcset) {
       const largestFromSrcset = getLargestImageFromSrcset(srcset);
       if (largestFromSrcset) {
@@ -121,6 +139,12 @@ async function extractImageUrls(doc: Document, articleUrl: string | null): Promi
         // Also remove sizes attribute if present, as it's only used with srcset
         img.removeAttribute('sizes');
       }
+    }
+
+    // Drop any <source> siblings so the browser falls back to the <img src>
+    // we rewrite to the downloaded image.
+    if (picture) {
+      picture.querySelectorAll("source").forEach((source) => source.remove());
     }
 
     // If the imgUrl is a relative URL or starts with '/', prepend the baseDirectory

--- a/lib/src/ingestion.ts
+++ b/lib/src/ingestion.ts
@@ -103,6 +103,11 @@ function getImageExtensionFromUrl(imgUrl: string): string {
 // ever see them, so the article ends up with no images. Hoist the largest
 // <source> srcset onto a srcless <img> *before* Readability runs so the image
 // survives parsing; extractImageUrls then downloads it and strips the sources.
+//
+// This is a workaround for a long-standing upstream gap (Readability's
+// _fixLazyImages only inspects an element's own attributes, never child
+// <source> elements). Background, history, and removal criteria:
+// docs/readability-lazy-picture-workaround.md
 export function hoistPictureSources(doc: Document): number {
   let hoisted = 0;
   doc.querySelectorAll("picture").forEach((picture) => {


### PR DESCRIPTION
## Summary
This PR adds proper handling for HTML `<picture>` elements with `<source>` children during image extraction. The browser gives `<source>` elements precedence over an `<img>`'s own src/srcset attributes, which was causing extracted articles to continue loading remote images instead of using the downloaded local copies.

## Key Changes
- **Export `extractImageUrls` function** to enable testing of the new functionality
- **Implement `<picture>/<source>` fallback logic**: When an `<img>` element lacks its own srcset, the code now checks for srcset attributes on sibling `<source>` elements and uses the largest image from the first available source
- **Remove `<source>` elements after extraction**: After processing, all `<source>` elements within a `<picture>` are removed to ensure the browser uses the rewritten `<img src>` pointing to downloaded images instead of the original remote URLs
- **Add comprehensive test coverage**: Four new test cases verify correct behavior for:
  - Medium-style markup (real image on `<img>`, `<source>` override removed)
  - Fallback to largest `<source>` srcset when `<img>` has no srcset
  - Preference for `<img>` srcset over `<source>` elements
  - Plain `<img>` elements without `<picture>` wrapper remain untouched

## Implementation Details
The solution prioritizes image sources in this order:
1. The `<img>` element's own srcset (if present)
2. The first `<source>` element's srcset within the parent `<picture>` (if no img srcset)
3. The `<img>` element's src attribute (fallback)

All `<source>` elements are removed after extraction to prevent the browser from overriding the locally-rewritten image URLs.

https://claude.ai/code/session_01Vi4V3Z1xQ9GBCyT3uDSbwS